### PR TITLE
Fixing branding errors, go back to bradselw

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,16 +1,16 @@
 <Project>
 
   <PropertyGroup>
-    <AssemblyName>DevOptional.System.Resources.$(MSBuildProjectName)</AssemblyName>
-    <RootNamespace>DevOptional.System.Resources.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
+    <AssemblyName>bradselw.System.Resources.$(MSBuildProjectName)</AssemblyName>
+    <RootNamespace>bradselw.System.Resources.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup>
     <Authors>bradselw</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/DevOptional/System.Resources</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/bradselw/System.Resources</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/DevOptional/System.Resources</RepositoryUrl>
+    <RepositoryUrl>https://github.com/bradselw/System.Resources</RepositoryUrl>
     <PackageTags>devops;system;resources</PackageTags>
   </PropertyGroup>
 

--- a/Registry/DefaultRegistryProxy.cs
+++ b/Registry/DefaultRegistryProxy.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using System.Linq;
 
-namespace DevOptional.System.Resources.Registry
+namespace bradselw.System.Resources.Registry
 {
     public class DefaultRegistryProxy : IRegistryProxy
     {

--- a/Registry/IRegistryProxy.cs
+++ b/Registry/IRegistryProxy.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Win32;
 
-namespace DevOptional.System.Resources.Registry
+namespace bradselw.System.Resources.Registry
 {
     public interface IRegistryProxy
     {


### PR DESCRIPTION
Reverting to `bradselw` namespace for now while searching for a new one.