### PR TITLE
Add method to delete a file on machine reboot

### DIFF
--- a/src/FileSystem/Abstractions/DefaultFileSystem.cs
+++ b/src/FileSystem/Abstractions/DefaultFileSystem.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.IO;
-using Windows.Win32;
+﻿using System.IO;
 
-namespace DevOptimal.SystemUtilities.FileSystem
+namespace DevOptimal.SystemUtilities.FileSystem.Abstractions
 {
     public class DefaultFileSystem : IFileSystem
     {
@@ -53,31 +51,12 @@ namespace DevOptimal.SystemUtilities.FileSystem
 
         public void HardLinkFile(string sourcePath, string destinationPath, bool overwrite)
         {
-            if (sourcePath == null)
-            {
-                throw new ArgumentNullException(nameof(sourcePath));
-            }
-            if (destinationPath == null)
-            {
-                throw new ArgumentNullException(nameof(destinationPath));
-            }
-
-            if (overwrite && File.Exists(destinationPath))
-            {
-                File.Delete(destinationPath);
-            }
-
-            PInvoke.CreateHardLink(@$"\\?\{destinationPath}", @$"\\?\{sourcePath}");
+            FileUtilities.HardLink(sourcePath, destinationPath, overwrite);
         }
 
         public void MoveFile(string sourcePath, string destinationPath, bool overwrite)
         {
-            if (overwrite && File.Exists(destinationPath))
-            {
-                File.Delete(destinationPath);
-            }
-
-            File.Move(sourcePath, destinationPath);
+            FileUtilities.Move(sourcePath, destinationPath, overwrite);
         }
 
         public FileStream OpenFile(string path, FileMode mode, FileAccess access, FileShare share)

--- a/src/FileSystem/Abstractions/IFileSystem.cs
+++ b/src/FileSystem/Abstractions/IFileSystem.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO;
 
-namespace DevOptimal.SystemUtilities.FileSystem
+namespace DevOptimal.SystemUtilities.FileSystem.Abstractions
 {
     public interface IFileSystem
     {

--- a/src/FileSystem/Abstractions/MockFileStream.cs
+++ b/src/FileSystem/Abstractions/MockFileStream.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Security.Cryptography;
 using System.Text;
 
-namespace DevOptimal.SystemUtilities.FileSystem
+namespace DevOptimal.SystemUtilities.FileSystem.Abstractions
 {
     public class MockFileStream : FileStream
     {

--- a/src/FileSystem/Abstractions/MockFileSystem.cs
+++ b/src/FileSystem/Abstractions/MockFileSystem.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 
-namespace DevOptimal.SystemUtilities.FileSystem
+namespace DevOptimal.SystemUtilities.FileSystem.Abstractions
 {
     public class MockFileSystem : IFileSystem
     {

--- a/src/FileSystem/Extensions/FileInfoExtensions.cs
+++ b/src/FileSystem/Extensions/FileInfoExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using DevOptimal.SystemUtilities.FileSystem.Abstractions;
 
 namespace DevOptimal.SystemUtilities.FileSystem.Extensions
 {

--- a/src/FileSystem/Extensions/IFileSystemExtensions.cs
+++ b/src/FileSystem/Extensions/IFileSystemExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using DevOptimal.SystemUtilities.FileSystem.Abstractions;
 
 namespace DevOptimal.SystemUtilities.FileSystem.Extensions
 {

--- a/src/FileSystem/FileUtilities.cs
+++ b/src/FileSystem/FileUtilities.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.InteropServices;
+using Windows.Win32;
+using Windows.Win32.Storage.FileSystem;
+
+namespace DevOptimal.SystemUtilities.FileSystem
+{
+    public static class FileUtilities
+    {
+        public static void DeleteOnReboot(string path)
+        {
+            if (!PInvoke.MoveFileEx(@$"\\?\{path}", null, MOVE_FILE_FLAGS.MOVEFILE_DELAY_UNTIL_REBOOT))
+            {
+                var errorCode = Marshal.GetLastWin32Error();
+                throw new Win32Exception(errorCode);
+            }
+        }
+
+        public static void HardLink(string sourceFileName, string destFileName, bool overwrite)
+        {
+            if (sourceFileName == null)
+            {
+                throw new ArgumentNullException(nameof(sourceFileName));
+            }
+            if (destFileName == null)
+            {
+                throw new ArgumentNullException(nameof(destFileName));
+            }
+
+            if (overwrite && File.Exists(destFileName))
+            {
+                File.Delete(destFileName);
+            }
+
+            if (!PInvoke.CreateHardLink(@$"\\?\{destFileName}", @$"\\?\{sourceFileName}"))
+            {
+                var errorCode = Marshal.GetLastWin32Error();
+                throw new Win32Exception(errorCode);
+            }
+        }
+
+        public static void Move(string sourceFileName, string destFileName, bool overwrite)
+        {
+            if (overwrite && File.Exists(destFileName))
+            {
+                File.Delete(destFileName);
+            }
+
+            File.Move(sourceFileName, destFileName);
+        }
+    }
+}

--- a/src/FileSystem/NativeMethods.txt
+++ b/src/FileSystem/NativeMethods.txt
@@ -1,1 +1,2 @@
 CreateHardLink
+MoveFileEx

--- a/src/FileSystem/TemporaryFile.cs
+++ b/src/FileSystem/TemporaryFile.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using DevOptimal.SystemUtilities.FileSystem.Abstractions;
 
 namespace DevOptimal.SystemUtilities.FileSystem
 {

--- a/test/FileSystem.Tests/MockFileSystemTests.cs
+++ b/test/FileSystem.Tests/MockFileSystemTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using DevOptimal.SystemUtilities.FileSystem.Abstractions;
 
 namespace DevOptimal.SystemUtilities.FileSystem.Tests
 {


### PR DESCRIPTION
Add `FileUtilities` static class that contains file-related helper methods similar to the `System.IO.File` class. Move `HardLink` and `Move` implementations to `FileUtilities`. Add new `DeleteOnReboot` method to `FileUtilities`.

Refactor `IFileSystem` types under the `DevOptimal.SystemUtilities.FileSystem.Abstractions` namespace.